### PR TITLE
Removed unnecessary map line, which actually adds a mapping using ( key

### DIFF
--- a/autoload/ncm2_dictionary.vim
+++ b/autoload/ncm2_dictionary.vim
@@ -23,7 +23,6 @@ function! ncm2_dictionary#on_complete(ctx)
       let l:matches = l:matches + readfile(l:dictionary)
     endfor
 
-    map(l:matches, "{'word': v:val}")
     let s:cache[&filetype] = l:matches
   endif
 


### PR DESCRIPTION
For me at least, this line was adding a mapping for the `(` key.  Also, removing it does not seem to affect the result (ie. dictionary words show up in completion)